### PR TITLE
Restore footer vent animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,6 +115,13 @@ realHead.load().then(function () {
       height = $('.illustration').height(),
       windowHeight = $(window).height(),
       distance = elementOffset - scrollTop - windowHeight;
+    if (distance < 0) {
+      //clearHeader, not clearheader - caps H
+      $(".illustration").addClass("animate");
+      // console.log(distance);
+    } else {
+      $(".illustration").removeClass("animate");
+    }
   };
 })();
 </script><script>(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
Re-enable the rotating vent animation in the footer SVG by restoring the
JavaScript code that adds the "animate" class when the illustration comes
into view during scrolling.