### PR TITLE
Update homepage shader to brand purple with white lines and thinner caret

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
 
         .caret {
             display: inline-block;
-            width: 0.6em;
+            width: 0.3em;
             height: 1em;
             background-color: #fff;
             margin-left: 0.1em;
@@ -105,36 +105,30 @@
             uniform vec2 u_resolution;
             uniform float u_time;
 
-            vec3 palette(float t) {
-                vec3 a = vec3(0.5, 0.5, 0.5);
-                vec3 b = vec3(0.5, 0.5, 0.5);
-                vec3 c = vec3(1.0, 1.0, 1.0);
-                vec3 d = vec3(0.263, 0.416, 0.557);
-                return a + b * cos(6.28318 * (c * t + d));
-            }
-
             void main() {
                 vec2 uv = (gl_FragCoord.xy * 2.0 - u_resolution.xy) / u_resolution.y;
                 vec2 uv0 = uv;
                 vec3 finalColor = vec3(0.0);
+
+                // Brand purple color (background)
+                vec3 brandPurple = vec3(0.486, 0.228, 0.929); // #7C3AED
 
                 for (float i = 0.0; i < 4.0; i++) {
                     uv = fract(uv * 1.5) - 0.5;
 
                     float d = length(uv) * exp(-length(uv0));
 
-                    vec3 col = palette(length(uv0) + i * 0.4 + u_time * 0.4);
-
                     d = sin(d * 8.0 + u_time) / 8.0;
                     d = abs(d);
 
                     d = pow(0.01 / d, 1.2);
 
-                    finalColor += col * d;
+                    // White lines
+                    finalColor += vec3(1.0, 1.0, 1.0) * d;
                 }
 
-                // Darken the effect for subtle background
-                finalColor *= 0.15;
+                // Mix with brand purple background
+                finalColor = finalColor * 0.15 + brandPurple * 0.3;
 
                 gl_FragColor = vec4(finalColor, 1.0);
             }


### PR DESCRIPTION
- Changed shader background to brand purple (#7C3AED)
- Updated shader lines to white for better contrast
- Reduced caret width from 0.6em to 0.3em for a sleeker appearance