### PR TITLE
Add five rotating shader variations to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,8 +99,10 @@
             }
         `;
 
-        // Fragment shader with cool wave effect
-        const fragmentShaderSource = `
+        // Five different shader variations
+        const shaderVariations = [
+            // Shader 1: Fractal waves (original)
+            `
             precision mediump float;
             uniform vec2 u_resolution;
             uniform float u_time;
@@ -110,29 +112,123 @@
                 vec2 uv0 = uv;
                 vec3 finalColor = vec3(0.0);
 
-                // Brand purple color (background)
-                vec3 brandPurple = vec3(0.486, 0.228, 0.929); // #7C3AED
+                vec3 brandPurple = vec3(0.486, 0.228, 0.929);
 
                 for (float i = 0.0; i < 4.0; i++) {
                     uv = fract(uv * 1.5) - 0.5;
-
                     float d = length(uv) * exp(-length(uv0));
-
                     d = sin(d * 8.0 + u_time) / 8.0;
                     d = abs(d);
-
                     d = pow(0.01 / d, 1.2);
-
-                    // White lines
                     finalColor += vec3(1.0, 1.0, 1.0) * d;
                 }
 
-                // Mix with brand purple background
                 finalColor = finalColor * 0.15 + brandPurple * 0.3;
-
                 gl_FragColor = vec4(finalColor, 1.0);
             }
-        `;
+            `,
+
+            // Shader 2: Grid lattice
+            `
+            precision mediump float;
+            uniform vec2 u_resolution;
+            uniform float u_time;
+
+            void main() {
+                vec2 uv = gl_FragCoord.xy / u_resolution.xy;
+                vec3 brandPurple = vec3(0.486, 0.228, 0.929);
+
+                vec2 grid = fract(uv * 10.0 + u_time * 0.1);
+                float pattern = smoothstep(0.0, 0.05, grid.x) * smoothstep(0.0, 0.05, grid.y);
+                pattern *= smoothstep(1.0, 0.95, grid.x) * smoothstep(1.0, 0.95, grid.y);
+
+                vec3 finalColor = mix(brandPurple * 0.3, vec3(1.0), pattern * 0.4);
+                gl_FragColor = vec4(finalColor, 1.0);
+            }
+            `,
+
+            // Shader 3: Radial waves
+            `
+            precision mediump float;
+            uniform vec2 u_resolution;
+            uniform float u_time;
+
+            void main() {
+                vec2 uv = (gl_FragCoord.xy * 2.0 - u_resolution.xy) / u_resolution.y;
+                vec3 brandPurple = vec3(0.486, 0.228, 0.929);
+
+                float d = length(uv);
+                float wave = sin(d * 10.0 - u_time * 2.0) * 0.5 + 0.5;
+                wave = pow(wave, 3.0);
+
+                vec3 finalColor = mix(brandPurple * 0.3, vec3(1.0), wave * 0.3);
+                gl_FragColor = vec4(finalColor, 1.0);
+            }
+            `,
+
+            // Shader 4: Organic noise
+            `
+            precision mediump float;
+            uniform vec2 u_resolution;
+            uniform float u_time;
+
+            float random(vec2 st) {
+                return fract(sin(dot(st.xy, vec2(12.9898,78.233))) * 43758.5453123);
+            }
+
+            float noise(vec2 st) {
+                vec2 i = floor(st);
+                vec2 f = fract(st);
+                float a = random(i);
+                float b = random(i + vec2(1.0, 0.0));
+                float c = random(i + vec2(0.0, 1.0));
+                float d = random(i + vec2(1.0, 1.0));
+                vec2 u = f * f * (3.0 - 2.0 * f);
+                return mix(a, b, u.x) + (c - a)* u.y * (1.0 - u.x) + (d - b) * u.x * u.y;
+            }
+
+            void main() {
+                vec2 uv = gl_FragCoord.xy / u_resolution.xy;
+                vec3 brandPurple = vec3(0.486, 0.228, 0.929);
+
+                float n = noise(uv * 5.0 + u_time * 0.2);
+                n += 0.5 * noise(uv * 10.0 + u_time * 0.3);
+                n /= 1.5;
+
+                vec3 finalColor = mix(brandPurple * 0.3, vec3(1.0), n * 0.3);
+                gl_FragColor = vec4(finalColor, 1.0);
+            }
+            `,
+
+            // Shader 5: Geometric triangular
+            `
+            precision mediump float;
+            uniform vec2 u_resolution;
+            uniform float u_time;
+
+            void main() {
+                vec2 uv = gl_FragCoord.xy / u_resolution.xy;
+                vec3 brandPurple = vec3(0.486, 0.228, 0.929);
+
+                vec2 pos = uv * 8.0 + u_time * 0.1;
+                vec2 cell = fract(pos);
+
+                float pattern = 0.0;
+                if (cell.x + cell.y < 1.0) {
+                    pattern = smoothstep(0.95, 1.0, cell.x + cell.y);
+                } else {
+                    pattern = smoothstep(0.95, 1.0, 2.0 - cell.x - cell.y);
+                }
+
+                vec3 finalColor = mix(brandPurple * 0.3, vec3(1.0), pattern * 0.5);
+                gl_FragColor = vec4(finalColor, 1.0);
+            }
+            `
+        ];
+
+        // Select a random shader on page load
+        const selectedShaderIndex = Math.floor(Math.random() * shaderVariations.length);
+        const fragmentShaderSource = shaderVariations[selectedShaderIndex];
 
         function createShader(gl, type, source) {
             const shader = gl.createShader(type);


### PR DESCRIPTION
Created five different WebGL shader effects that rotate randomly on page refresh:
- Fractal waves (original)
- Grid lattice pattern
- Radial waves
- Organic noise
- Geometric triangular tessellation

All shaders use the brand purple (#7C3AED) and white color scheme.