### PR TITLE
Make sharp the default output option

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,8 +216,8 @@
             <label for="output-select">Output</label>
             <div class="select-wrapper">
                 <select id="output-select">
-                    <option value="smooth">Smooth (Default)</option>
-                    <option value="sharp">Sharp</option>
+                    <option value="smooth">Smooth</option>
+                    <option value="sharp" selected>Sharp (Default)</option>
                 </select>
             </div>
         </div>
@@ -284,7 +284,7 @@
 
         // --- Configuration ---
         let currentPreset = PRESETS.macintosh;
-        let currentOutput = 'smooth';
+        let currentOutput = 'sharp';
         let logoTexture = null; // Defined at top level to avoid ReferenceError
         let logoGroup = null;
 


### PR DESCRIPTION
Updated the output selector to default to "sharp" mode instead of "smooth". This provides chunkier pixels (2.0 pixel size) and nearest-neighbor filtering for a more retro aesthetic by default.