### PR TITLE
Fix firework position drift caused by rotating debrisGroup

### DIFF
--- a/index.html
+++ b/index.html
@@ -405,7 +405,8 @@
                 this.lifetime = 0;
                 this.maxLifetime = 120; // ~2 seconds at 60fps
 
-                debrisGroup.add(this.mesh);
+                // Add to scene directly to avoid rotation drift from debrisGroup
+                scene.add(this.mesh);
             }
 
             update() {
@@ -436,7 +437,7 @@
             }
 
             destroy() {
-                debrisGroup.remove(this.mesh);
+                scene.remove(this.mesh);
                 this.mesh.geometry.dispose();
                 this.mesh.material.dispose();
             }


### PR DESCRIPTION
The issue was that particles were being added to debrisGroup, which continuously rotates in the animation loop. As the group accumulated rotation, newly spawned particles inherited the group's transform, causing them to appear progressively further from the clicked position.

Solution: Add firework particles directly to the scene instead of debrisGroup, preventing them from being affected by the group's rotation.