### PR TITLE
Add balanced dithering for clearer colors without being too chunky

### DIFF
--- a/index.html
+++ b/index.html
@@ -512,7 +512,8 @@
                 'uLightColor': { value: currentPreset.light },
                 'uDarkColor': { value: currentPreset.dark },
                 'uThreshold': { value: currentPreset.threshold },
-                'uPixelSize': { value: 1.0 } // Controlled by Output
+                'uPixelSize': { value: 1.0 }, // Controlled by Output
+                'uDitherScale': { value: 1.5 } // Scale of dither pattern
             },
             vertexShader: `
                 varying vec2 vUv;
@@ -528,6 +529,7 @@
                 uniform vec3 uDarkColor;
                 uniform float uThreshold;
                 uniform float uPixelSize;
+                uniform float uDitherScale;
 
                 varying vec2 vUv;
 
@@ -546,11 +548,15 @@
                     // Pixelize coordinate
                     vec2 pixelCoord = floor(gl_FragCoord.xy / uPixelSize);
 
-                    // Sample texture
-                    vec4 texel = texture2D(tDiffuse, vUv);
+                    // Scale the dither pattern for better visibility
+                    vec2 ditherCoord = floor(pixelCoord / uDitherScale);
+
+                    // Sample texture with slight pixelization
+                    vec2 pixelUv = floor(vUv * uResolution / uPixelSize) / (uResolution / uPixelSize);
+                    vec4 texel = texture2D(tDiffuse, pixelUv);
 
                     float lum = dot(texel.rgb, vec3(0.299, 0.587, 0.114));
-                    float ditherValue = bayer4x4(pixelCoord);
+                    float ditherValue = bayer4x4(ditherCoord);
 
                     vec3 finalColor = (lum < ditherValue) ? uDarkColor : uLightColor;
                     gl_FragColor = vec4(finalColor, 1.0);
@@ -580,14 +586,16 @@
             // Output Mode (Pixel Size)
             const outputMode = outputSelect.value;
             if (outputMode === 'sharp') {
-                ditherPass.uniforms.uPixelSize.value = 2.0; // Chunkier pixels
+                ditherPass.uniforms.uPixelSize.value = 2.0; // Medium pixel blocks
+                ditherPass.uniforms.uDitherScale.value = 2.0; // Medium dither pattern
                 if(logoTexture) {
                     logoTexture.minFilter = THREE.NearestFilter;
                     logoTexture.magFilter = THREE.NearestFilter;
                     logoTexture.needsUpdate = true;
                 }
             } else {
-                ditherPass.uniforms.uPixelSize.value = 1.0; // Native resolution
+                ditherPass.uniforms.uPixelSize.value = 1.0; // Minimal pixelization
+                ditherPass.uniforms.uDitherScale.value = 1.5; // Subtle dither scaling
                 if(logoTexture) {
                     logoTexture.minFilter = THREE.LinearFilter;
                     logoTexture.magFilter = THREE.LinearFilter;


### PR DESCRIPTION
Implemented medium-sized dithering that balances visibility with aesthetics:
- Sharp mode: 2x2 pixel blocks with 2x dither scaling
- Smooth mode: 1x pixels with 1.5x dither scaling
- Added dither scale parameter to enlarge pattern blocks
- Improved texture sampling to prevent color muddiness

This provides a middle ground between the original dense dithering (which made colors look dull) and overly chunky pixels, making both colors clearly visible while maintaining visual quality.