### PR TITLE
Use solid colors like Obra Dinn with dithering only for mid-tones

### DIFF
--- a/index.html
+++ b/index.html
@@ -545,20 +545,35 @@
                 }
 
                 void main() {
-                    // Pixelize coordinate with larger blocks
+                    // Pixelize coordinate
                     vec2 pixelCoord = floor(gl_FragCoord.xy / uPixelSize);
 
-                    // Scale down the dither pattern to make it chunkier
+                    // Scale the dither pattern
                     vec2 ditherCoord = floor(pixelCoord / uDitherScale);
 
-                    // Sample texture at pixelized UV
+                    // Sample texture with pixelization
                     vec2 pixelUv = floor(vUv * uResolution / uPixelSize) / (uResolution / uPixelSize);
                     vec4 texel = texture2D(tDiffuse, pixelUv);
 
                     float lum = dot(texel.rgb, vec3(0.299, 0.587, 0.114));
-                    float ditherValue = bayer4x4(ditherCoord);
 
-                    vec3 finalColor = (lum < ditherValue) ? uDarkColor : uLightColor;
+                    // Solid colors for darks and lights, dither only mid-tones
+                    // This matches Obra Dinn's aesthetic: solid blacks and whites dominate
+                    vec3 finalColor;
+                    if (lum < 0.3) {
+                        // Dark areas: solid dark color
+                        finalColor = uDarkColor;
+                    } else if (lum > 0.7) {
+                        // Light areas: solid light color
+                        finalColor = uLightColor;
+                    } else {
+                        // Mid-tones: use dithering
+                        float ditherValue = bayer4x4(ditherCoord);
+                        // Remap luminance from [0.3, 0.7] to [0, 1] for dithering
+                        float remappedLum = (lum - 0.3) / 0.4;
+                        finalColor = (remappedLum < ditherValue) ? uDarkColor : uLightColor;
+                    }
+
                     gl_FragColor = vec4(finalColor, 1.0);
                 }
             `
@@ -586,16 +601,16 @@
             // Output Mode (Pixel Size)
             const outputMode = outputSelect.value;
             if (outputMode === 'sharp') {
-                ditherPass.uniforms.uPixelSize.value = 3.0; // Much chunkier pixels like Obra Dinn
-                ditherPass.uniforms.uDitherScale.value = 3.0; // Larger dither blocks
+                ditherPass.uniforms.uPixelSize.value = 2.0; // Moderate pixel blocks
+                ditherPass.uniforms.uDitherScale.value = 2.0; // Moderate dither pattern
                 if(logoTexture) {
                     logoTexture.minFilter = THREE.NearestFilter;
                     logoTexture.magFilter = THREE.NearestFilter;
                     logoTexture.needsUpdate = true;
                 }
             } else {
-                ditherPass.uniforms.uPixelSize.value = 1.5; // Slightly pixelized
-                ditherPass.uniforms.uDitherScale.value = 2.0; // Medium dither blocks
+                ditherPass.uniforms.uPixelSize.value = 1.0; // Smooth resolution
+                ditherPass.uniforms.uDitherScale.value = 1.5; // Subtle dither scaling
                 if(logoTexture) {
                     logoTexture.minFilter = THREE.LinearFilter;
                     logoTexture.magFilter = THREE.LinearFilter;


### PR DESCRIPTION
Matches the actual Obra Dinn aesthetic where:
- Dark areas (lum < 0.3) are solid dark color
- Light areas (lum > 0.7) are solid light color
- Mid-tones (0.3-0.7) use dithering for shading

This creates the clean, high-contrast look seen in the game where solid blacks and whites dominate the image, with dithering used sparingly only for shadows and highlights. No more constant heavy dithering across the entire scene.