### PR TITLE
Fix graphics picker background to match site background

### DIFF
--- a/index.html
+++ b/index.html
@@ -682,10 +682,9 @@
             const bgColor = useLightTheme ? `#${preset.light.getHexString()}` : '#000';
             document.body.style.backgroundColor = bgColor;
 
-            // Update UI layer - background color with foreground text
+            // Update UI layer - use same background as site, with foreground text
             const foregroundColor = `#${preset.light.getHexString()}`;
-            const backgroundColor = `#${preset.dark.getHexString()}`;
-            uiLayer.style.backgroundColor = backgroundColor;
+            uiLayer.style.backgroundColor = bgColor;
             uiLayer.style.color = foregroundColor;
             uiLayer.style.borderColor = foregroundColor;
 


### PR DESCRIPTION
The graphics picker (UI layer) now uses the same background color as the site in all modes:
- Dark mode: both use #000 (black)
- Light mode: both use preset.light color

Previously the picker was using preset.dark which didn't match the site background.