### PR TITLE
Use consistent white background for graphics picker in light mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -682,9 +682,10 @@
             const bgColor = useLightTheme ? `#${preset.light.getHexString()}` : '#000';
             document.body.style.backgroundColor = bgColor;
 
-            // Update UI layer - use same background as site, with foreground text
+            // Update UI layer - use consistent background for all graphics modes
             const foregroundColor = `#${preset.light.getHexString()}`;
-            uiLayer.style.backgroundColor = bgColor;
+            const pickerBgColor = useLightTheme ? '#ffffff' : '#000';
+            uiLayer.style.backgroundColor = pickerBgColor;
             uiLayer.style.color = foregroundColor;
             uiLayer.style.borderColor = foregroundColor;
 

--- a/index.html
+++ b/index.html
@@ -678,14 +678,13 @@
                 }
             }
 
-            // Update background color based on theme
-            const bgColor = useLightTheme ? `#${preset.light.getHexString()}` : '#000';
+            // Update background color based on theme - use preset's background color
+            const bgColor = useLightTheme ? `#${preset.light.getHexString()}` : `#${preset.dark.getHexString()}`;
             document.body.style.backgroundColor = bgColor;
 
-            // Update UI layer - use consistent background for all graphics modes
-            const foregroundColor = `#${preset.light.getHexString()}`;
-            const pickerBgColor = useLightTheme ? '#ffffff' : '#000';
-            uiLayer.style.backgroundColor = pickerBgColor;
+            // Update UI layer - use same background as body for all graphics modes
+            const foregroundColor = useLightTheme ? `#${preset.dark.getHexString()}` : `#${preset.light.getHexString()}`;
+            uiLayer.style.backgroundColor = bgColor;
             uiLayer.style.color = foregroundColor;
             uiLayer.style.borderColor = foregroundColor;
 


### PR DESCRIPTION
The graphics mode picker now uses #ffffff (white) as background in light mode
for all graphics modes, matching the consistent behavior of dark mode which
uses #000 (black) across all modes.