### PR TITLE
Hide drag/zoom instructions on portrait phones

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,6 +214,13 @@
             }
         }
 
+        /* Hide instructions on portrait phones */
+        @media (max-width: 768px) and (orientation: portrait) {
+            .instructions {
+                display: none;
+            }
+        }
+
     </style>
 </head>
 <body>


### PR DESCRIPTION
Add media query to hide the instructions div when device is in portrait
orientation on mobile devices (max-width: 768px). This improves the mobile
UX by removing text that takes up valuable screen space on portrait phones.